### PR TITLE
fun trait is defined and implemented

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "orx-closure"
-version = "0.0.1"
+version = "0.1.0"
 edition = "2021"
 authors = ["orxfun <orx.ugur.arikan@gmail.com>"]
 description = "An explicit closure with absolute seperation of the captured data from the function."

--- a/README.md
+++ b/README.md
@@ -325,7 +325,39 @@ To sum up, once the ugliness is hidden in a small box, `Closure` provides a conv
 
 This middle ground fits well with closures having specific functionalities such as the `Precedence`.
 
-## C. Relation with `Fn` trait
+## C. Abstraction over the Captured Data with Trait Objects
+
+As mentioned, we are not able to implement `fn_traits` in stable rust. As also mentioned, abstraction over the captured data type is the core power of closures. In order to achieve this flexibility, this crate provides the required traits `Fun`, `FunRef`, `FunOptRef` and `FunResRef`. The following table provides the complete list of traits and types implementing them.
+
+| Trait                       | Transformation              | Struct                                                |
+|-----------------------------|-----------------------------|-------------------------------------------------------|
+| `Fun<In, Out>`              | `In -> Out`                 | `T where T: Fn(In) -> Out`                            |
+|                             |                             | `Closure<Capture, In, Out>`                           |
+|                             |                             | `ClosureOneOf2<C1, C2, In, Out>`                      |
+|                             |                             | `ClosureOneOf3<C1, C2, C3, In, Out>`                  |
+|                             |                             | `ClosureOneOf4<C1, C2, C3, C4, In, Out>`              |
+| `FunRef<In, Out>`           | `In -> &Out`                | `ClosureRef<Capture, In, Out>`                        |
+|                             |                             | `ClosureRefOneOf2<C1, C2, In, Out>`                   |
+|                             |                             | `ClosureRefOneOf3<C1, C2, C3, In, Out>`               |
+|                             |                             | `ClosureRefOneOf4<C1, C2, C3, C4, In, Out>`           |
+| `FunOptRef<In, Out>`        | `In -> Option<&Out>`        | `ClosureOptRef<Capture, In, Out>`                     |
+|                             |                             | `ClosureOptRefOneOf2<C1, C2, In, Out>`                |
+|                             |                             | `ClosureOptRefOneOf3<C1, C2, C3, In, Out>`            |
+|                             |                             | `ClosureOptRefOneOf4<C1, C2, C3, C4, In, Out>`        |
+| `FunResRef<In, Out, Error>` | `In -> Result<&Out, Error>` | `ClosureResRef<Capture, In, Out, Error>`              |
+|                             |                             | `ClosureResRefOneOf2<C1, C2, In, Out, Error>`         |
+|                             |                             | `ClosureResRefOneOf3<C1, C2, C3, In, Out, Error>`     |
+|                             |                             | `ClosureResRefOneOf4<C1, C2, C3, C4, In, Out, Error>` |
+
+The fun traits are useful due to the following:
+
+* The are to be used as a generic parameter which can be filled up by any of the implementing types. This is exactly the purpose of the `Fn` traits. The two reasons why we don't directly use the `Fn` trait is as follows:
+  * We are not allowed to implement `Fn` trait in stable rust for the `Capture` types defined in this crate.
+  * Apart from `Fun`, we are not able to represent the reference-returning traits with the `Fn` trait due to lifetime errors.
+* They allow to create trait objects from the closures, such as `dyn Fun<In, Out>`, etc., whenever we do not (want to) know the capture type.
+
+
+## D. Relation with `Fn` trait
 
 Note that `Closure<Capture, In, Out>` has the method `fn call(&self, input: In) -> Out`. Therefore, it could have implemented `Fn(In) -> Out`. But the compiler tells me that *manual implementations of `Fn` are experimental*, and adds the *use of unstable library feature 'fn_traits'* error. Not wanting to be unstable, `Closure` does not implement the `Fn` trait.
 

--- a/src/closure_opt_ref.rs
+++ b/src/closure_opt_ref.rs
@@ -1,3 +1,4 @@
+use crate::fun::FunOptRef;
 use std::fmt::Debug;
 
 /// Closure strictly separating the captured data from the function, and hence, having two components:
@@ -69,6 +70,11 @@ impl<Capture, In, Out: ?Sized> ClosureOptRef<Capture, In, Out> {
         (self.fun)(&self.capture, input)
     }
 
+    /// Returns a reference to the captured data.
+    pub fn captured_data(&self) -> &Capture {
+        &self.capture
+    }
+
     /// Consumes the closure and returns back the captured data.
     ///
     /// # Example
@@ -112,5 +118,11 @@ impl<Capture, In, Out: ?Sized> ClosureOptRef<Capture, In, Out> {
     /// ```
     pub fn as_fn<'a>(&'a self) -> impl Fn(In) -> Option<&'a Out> {
         move |x| self.call(x)
+    }
+}
+
+impl<Capture, In, Out: ?Sized> FunOptRef<In, Out> for ClosureOptRef<Capture, In, Out> {
+    fn call(&self, input: In) -> Option<&Out> {
+        ClosureOptRef::call(self, input)
     }
 }

--- a/src/closure_ref.rs
+++ b/src/closure_ref.rs
@@ -1,3 +1,4 @@
+use crate::fun::FunRef;
 use std::fmt::Debug;
 
 /// Closure strictly separating the captured data from the function, and hence, having two components:
@@ -67,6 +68,11 @@ impl<Capture, In, Out: ?Sized> ClosureRef<Capture, In, Out> {
         (self.fun)(&self.capture, input)
     }
 
+    /// Returns a reference to the captured data.
+    pub fn captured_data(&self) -> &Capture {
+        &self.capture
+    }
+
     /// Consumes the closure and returns back the captured data.
     ///
     /// ```rust
@@ -106,5 +112,11 @@ impl<Capture, In, Out: ?Sized> ClosureRef<Capture, In, Out> {
     /// ```
     pub fn as_fn<'a>(&'a self) -> impl Fn(In) -> &'a Out {
         move |x| self.call(x)
+    }
+}
+
+impl<Capture, In, Out: ?Sized> FunRef<In, Out> for ClosureRef<Capture, In, Out> {
+    fn call(&self, input: In) -> &Out {
+        ClosureRef::call(self, input)
     }
 }

--- a/src/closure_res_ref.rs
+++ b/src/closure_res_ref.rs
@@ -1,3 +1,4 @@
+use crate::fun::FunResRef;
 use std::fmt::Debug;
 
 /// Closure strictly separating the captured data from the function, and hence, having two components:
@@ -75,6 +76,11 @@ impl<Capture, In, Out: ?Sized, Error> ClosureResRef<Capture, In, Out, Error> {
         (self.fun)(&self.capture, input)
     }
 
+    /// Returns a reference to the captured data.
+    pub fn captured_data(&self) -> &Capture {
+        &self.capture
+    }
+
     /// Consumes the closure and returns back the captured data.
     ///
     /// ```rust
@@ -119,5 +125,13 @@ impl<Capture, In, Out: ?Sized, Error> ClosureResRef<Capture, In, Out, Error> {
     /// ```
     pub fn as_fn<'a>(&'a self) -> impl Fn(In) -> Result<&'a Out, Error> {
         move |x| self.call(x)
+    }
+}
+
+impl<Capture, In, Out: ?Sized, Error> FunResRef<In, Out, Error>
+    for ClosureResRef<Capture, In, Out, Error>
+{
+    fn call(&self, input: In) -> Result<&Out, Error> {
+        ClosureResRef::call(self, input)
     }
 }

--- a/src/closure_val.rs
+++ b/src/closure_val.rs
@@ -1,5 +1,7 @@
 use std::fmt::Debug;
 
+use crate::fun::Fun;
+
 /// Closure strictly separating the captured data from the function, and hence, having two components:
 ///
 /// * `Capture` is any captured data,
@@ -62,6 +64,11 @@ impl<Capture, In, Out> Closure<Capture, In, Out> {
         (self.fun)(&self.capture, input)
     }
 
+    /// Returns a reference to the captured data.
+    pub fn captured_data(&self) -> &Capture {
+        &self.capture
+    }
+
     /// Consumes the closure and returns back the captured data.
     ///
     /// ```rust
@@ -106,5 +113,11 @@ impl<Capture, In, Out> Closure<Capture, In, Out> {
     /// ```
     pub fn as_fn(&self) -> impl Fn(In) -> Out + '_ {
         |x| self.call(x)
+    }
+}
+
+impl<Capture, In, Out> Fun<In, Out> for Closure<Capture, In, Out> {
+    fn call(&self, input: In) -> Out {
+        Closure::call(self, input)
     }
 }

--- a/src/fun.rs
+++ b/src/fun.rs
@@ -1,0 +1,72 @@
+/// Function trait representing `In -> Out` transformation.
+///
+/// It provides the common interface for closures, such as `Closure<Capture, In, Out>`, over all capture types.
+///
+/// Furthermore, this trait enables to forget about the capture, or equivalently drop the `Capture` generic parameter, by using `dyn Fun<In, Out>` trait object.
+///
+/// # Relation with `Fn`
+///
+/// `Fun<In, Out>` can be considered equivalent to `Fn(In) -> Out`.
+/// The reason it co-exists is that it is not possible to implement `fn_traits` in stable version.
+///
+/// However, all that implements `Fn(In) -> Out` also auto-implements `Fun<In, Out>`.
+pub trait Fun<In, Out> {
+    /// Calls the function with the given `input` and returns the produced output.
+    fn call(&self, input: In) -> Out;
+}
+impl<In, Out, F: Fn(In) -> Out> Fun<In, Out> for F {
+    fn call(&self, input: In) -> Out {
+        self(input)
+    }
+}
+
+/// Function trait representing `In -> &Out` transformation.
+///
+/// It provides the common interface for closures, such as `ClosureRef<Capture, In, Out>`, over all capture types.
+///
+/// Furthermore, this trait enables to forget about the capture, or equivalently drop the `Capture` generic parameter, by using `dyn FunRef<In, Out>` trait object.
+///
+/// # Relation with `Fn`
+///
+/// `FunRef<In, Out>` can be considered equivalent to `Fn(In) -> &Out`.
+///
+/// However, it appears to be impossible to have an instance of the latter due to lifetime errors.
+/// Therefore, `FunRef<In, Out>` is required.
+pub trait FunRef<In, Out: ?Sized> {
+    /// Calls the function with the given `input` and returns the produced output.
+    fn call(&self, input: In) -> &Out;
+}
+
+/// Function trait representing `In -> Option<&Out>` transformation.
+///
+/// It provides the common interface for closures, such as `ClosureOptRef<Capture, In, Out>`, over all capture types.
+///
+/// Furthermore, this trait enables to forget about the capture, or equivalently drop the `Capture` generic parameter, by using `dyn FunOptRef<In, Out>` trait object.
+///
+/// # Relation with `Fn`
+///
+/// `FunOptRef<In, Out>` can be considered equivalent to `Fn(In) -> Option<&Out>`.
+///
+/// However, it appears to be impossible to have an instance of the latter due to lifetime errors.
+/// Therefore, `FunOptRef<In, Out>` is required.
+pub trait FunOptRef<In, Out: ?Sized> {
+    /// Calls the function with the given `input` and returns the produced output.
+    fn call(&self, input: In) -> Option<&Out>;
+}
+
+/// Function trait representing `In -> Result<&Out, Error>` transformation.
+///
+/// It provides the common interface for closures, such as `ClosureResRef<Capture, In, Out>`, over all capture types.
+///
+/// Furthermore, this trait enables to forget about the capture, or equivalently drop the `Capture` generic parameter, by using `dyn FunOptRef<In, Out>` trait object.
+///
+/// # Relation with `Fn`
+///
+/// `FunResRef<In, Out, Error>` can be considered equivalent to `Fn(In) -> Result<&Out, Error>`.
+///
+/// However, it appears to be impossible to have an instance of the latter due to lifetime errors.
+/// Therefore, `FunResRef<In, Out, Error>` is required.
+pub trait FunResRef<In, Out: ?Sized, Error> {
+    /// Calls the function with the given `input` and returns the produced output.
+    fn call(&self, input: In) -> Result<&Out, Error>;
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -335,7 +335,39 @@
 //!
 //! This middle ground fits well with closures having specific functionalities such as the `Precedence`.
 //!
-//! ## C. Relation with `Fn` trait
+//! ## C. Abstraction over the Captured Data with Trait Objects
+//!
+//! As mentioned, we are not able to implement `fn_traits` in stable rust. As also mentioned, abstraction over the captured data type is the core power of closures. In order to achieve this flexibility, this crate provides the required traits `Fun`, `FunRef`, `FunOptRef` and `FunResRef`. The following table provides the complete list of traits and types implementing them.
+//!
+//! | Trait                       | Transformation              | Struct                                                |
+//! |-----------------------------|-----------------------------|-------------------------------------------------------|
+//! | `Fun<In, Out>`              | `In -> Out`                 | `T where T: Fn(In) -> Out`                            |
+//! |                             |                             | `Closure<Capture, In, Out>`                           |
+//! |                             |                             | `ClosureOneOf2<C1, C2, In, Out>`                      |
+//! |                             |                             | `ClosureOneOf3<C1, C2, C3, In, Out>`                  |
+//! |                             |                             | `ClosureOneOf4<C1, C2, C3, C4, In, Out>`              |
+//! | `FunRef<In, Out>`           | `In -> &Out`                | `ClosureRef<Capture, In, Out>`                        |
+//! |                             |                             | `ClosureRefOneOf2<C1, C2, In, Out>`                   |
+//! |                             |                             | `ClosureRefOneOf3<C1, C2, C3, In, Out>`               |
+//! |                             |                             | `ClosureRefOneOf4<C1, C2, C3, C4, In, Out>`           |
+//! | `FunOptRef<In, Out>`        | `In -> Option<&Out>`        | `ClosureOptRef<Capture, In, Out>`                     |
+//! |                             |                             | `ClosureOptRefOneOf2<C1, C2, In, Out>`                |
+//! |                             |                             | `ClosureOptRefOneOf3<C1, C2, C3, In, Out>`            |
+//! |                             |                             | `ClosureOptRefOneOf4<C1, C2, C3, C4, In, Out>`        |
+//! | `FunResRef<In, Out, Error>` | `In -> Result<&Out, Error>` | `ClosureResRef<Capture, In, Out, Error>`              |
+//! |                             |                             | `ClosureResRefOneOf2<C1, C2, In, Out, Error>`         |
+//! |                             |                             | `ClosureResRefOneOf3<C1, C2, C3, In, Out, Error>`     |
+//! |                             |                             | `ClosureResRefOneOf4<C1, C2, C3, C4, In, Out, Error>` |
+//!
+//! The fun traits are useful due to the following:
+//!
+//! * The are to be used as a generic parameter which can be filled up by any of the implementing types. This is exactly the purpose of the `Fn` traits. The two reasons why we don't directly use the `Fn` trait is as follows:
+//!   * We are not allowed to implement `Fn` trait in stable rust for the `Capture` types defined in this crate.
+//!   * Apart from `Fun`, we are not able to represent the reference-returning traits with the `Fn` trait due to lifetime errors.
+//! * They allow to create trait objects from the closures, such as `dyn Fun<In, Out>`, etc., whenever we do not (want to) know the capture type.
+//!
+//!
+//! ## D. Relation with `Fn` trait
 //!
 //! Note that `Closure<Capture, In, Out>` has the method `fn call(&self, input: In) -> Out`. Therefore, it could have implemented `Fn(In) -> Out`. But the compiler tells me that *manual implementations of `Fn` are experimental*, and adds the *use of unstable library feature 'fn_traits'* error. Not wanting to be unstable, `Closure` does not implement the `Fn` trait.
 //!
@@ -362,6 +394,7 @@ mod closure_opt_ref;
 mod closure_ref;
 mod closure_res_ref;
 mod closure_val;
+mod fun;
 mod one_of;
 mod one_of_variants;
 
@@ -386,3 +419,5 @@ pub use one_of_variants::one_of4::{
     closure_opt_ref::ClosureOptRefOneOf4, closure_ref::ClosureRefOneOf4,
     closure_res_ref::ClosureResRefOneOf4, closure_val::ClosureOneOf4,
 };
+
+pub use fun::{Fun, FunOptRef, FunRef, FunResRef};

--- a/src/one_of_variants/one_of2/closure_opt_ref.rs
+++ b/src/one_of_variants/one_of2/closure_opt_ref.rs
@@ -1,4 +1,4 @@
-use crate::{ClosureOptRef, OneOf2};
+use crate::{fun::FunOptRef, ClosureOptRef, OneOf2};
 
 /// `ClosureOptRefOneOf2<C1, C2, In, Out>` is a union of two closures:
 ///
@@ -135,6 +135,14 @@ impl<C1, C2, In, Out: ?Sized> ClosureOptRefOneOf2<C1, C2, In, Out> {
         match &self.closure {
             OneOf2::Variant1(fun) => fun.call(input),
             OneOf2::Variant2(fun) => fun.call(input),
+        }
+    }
+
+    /// Returns a reference to the captured data.
+    pub fn captured_data(&self) -> OneOf2<&C1, &C2> {
+        match &self.closure {
+            OneOf2::Variant1(x) => OneOf2::Variant1(x.captured_data()),
+            OneOf2::Variant2(x) => OneOf2::Variant2(x.captured_data()),
         }
     }
 
@@ -359,5 +367,11 @@ impl<Capture, In, Out: ?Sized> ClosureOptRef<Capture, In, Out> {
     pub fn into_oneof2_var2<Var1>(self) -> ClosureOptRefOneOf2<Var1, Capture, In, Out> {
         let closure = OneOf2::Variant2(self);
         ClosureOptRefOneOf2 { closure }
+    }
+}
+
+impl<C1, C2, In, Out: ?Sized> FunOptRef<In, Out> for ClosureOptRefOneOf2<C1, C2, In, Out> {
+    fn call(&self, input: In) -> Option<&Out> {
+        ClosureOptRefOneOf2::call(self, input)
     }
 }

--- a/src/one_of_variants/one_of2/closure_ref.rs
+++ b/src/one_of_variants/one_of2/closure_ref.rs
@@ -1,4 +1,4 @@
-use crate::{ClosureRef, OneOf2};
+use crate::{fun::FunRef, ClosureRef, OneOf2};
 
 /// `ClosureRefOneOf2<C1, C2, In, Out>` is a union of two closures:
 ///
@@ -132,6 +132,14 @@ impl<C1, C2, In, Out: ?Sized> ClosureRefOneOf2<C1, C2, In, Out> {
         match &self.closure {
             OneOf2::Variant1(fun) => fun.call(input),
             OneOf2::Variant2(fun) => fun.call(input),
+        }
+    }
+
+    /// Returns a reference to the captured data.
+    pub fn captured_data(&self) -> OneOf2<&C1, &C2> {
+        match &self.closure {
+            OneOf2::Variant1(x) => OneOf2::Variant1(x.captured_data()),
+            OneOf2::Variant2(x) => OneOf2::Variant2(x.captured_data()),
         }
     }
 
@@ -350,5 +358,11 @@ impl<Capture, In, Out: ?Sized> ClosureRef<Capture, In, Out> {
     pub fn into_oneof2_var2<Var1>(self) -> ClosureRefOneOf2<Var1, Capture, In, Out> {
         let closure = OneOf2::Variant2(self);
         ClosureRefOneOf2 { closure }
+    }
+}
+
+impl<C1, C2, In, Out: ?Sized> FunRef<In, Out> for ClosureRefOneOf2<C1, C2, In, Out> {
+    fn call(&self, input: In) -> &Out {
+        ClosureRefOneOf2::call(self, input)
     }
 }

--- a/src/one_of_variants/one_of2/closure_res_ref.rs
+++ b/src/one_of_variants/one_of2/closure_res_ref.rs
@@ -1,4 +1,4 @@
-use crate::{ClosureResRef, OneOf2};
+use crate::{fun::FunResRef, ClosureResRef, OneOf2};
 
 type UnionClosure<C1, C2, In, Out, Error> =
     OneOf2<ClosureResRef<C1, In, Out, Error>, ClosureResRef<C2, In, Out, Error>>;
@@ -149,6 +149,14 @@ impl<C1, C2, In, Out: ?Sized, Error> ClosureResRefOneOf2<C1, C2, In, Out, Error>
         match &self.closure {
             OneOf2::Variant1(fun) => fun.call(input),
             OneOf2::Variant2(fun) => fun.call(input),
+        }
+    }
+
+    /// Returns a reference to the captured data.
+    pub fn captured_data(&self) -> OneOf2<&C1, &C2> {
+        match &self.closure {
+            OneOf2::Variant1(x) => OneOf2::Variant1(x.captured_data()),
+            OneOf2::Variant2(x) => OneOf2::Variant2(x.captured_data()),
         }
     }
 
@@ -390,5 +398,13 @@ impl<Capture, In, Out: ?Sized, Error> ClosureResRef<Capture, In, Out, Error> {
     pub fn into_oneof2_var2<Var1>(self) -> ClosureResRefOneOf2<Var1, Capture, In, Out, Error> {
         let closure = OneOf2::Variant2(self);
         ClosureResRefOneOf2 { closure }
+    }
+}
+
+impl<C1, C2, In, Out: ?Sized, Error> FunResRef<In, Out, Error>
+    for ClosureResRefOneOf2<C1, C2, In, Out, Error>
+{
+    fn call(&self, input: In) -> Result<&Out, Error> {
+        ClosureResRefOneOf2::call(self, input)
     }
 }

--- a/src/one_of_variants/one_of2/closure_val.rs
+++ b/src/one_of_variants/one_of2/closure_val.rs
@@ -1,4 +1,4 @@
-use crate::{Closure, OneOf2};
+use crate::{fun::Fun, Closure, OneOf2};
 
 /// `ClosureOneOf2<C1, C2, In, Out>` is a union of two closures:
 ///
@@ -117,6 +117,14 @@ impl<C1, C2, In, Out> ClosureOneOf2<C1, C2, In, Out> {
         match &self.closure {
             OneOf2::Variant1(fun) => fun.call(input),
             OneOf2::Variant2(fun) => fun.call(input),
+        }
+    }
+
+    /// Returns a reference to the captured data.
+    pub fn captured_data(&self) -> OneOf2<&C1, &C2> {
+        match &self.closure {
+            OneOf2::Variant1(x) => OneOf2::Variant1(x.captured_data()),
+            OneOf2::Variant2(x) => OneOf2::Variant2(x.captured_data()),
         }
     }
 
@@ -288,5 +296,11 @@ impl<Capture, In, Out> Closure<Capture, In, Out> {
     pub fn into_oneof2_var2<Var1>(self) -> ClosureOneOf2<Var1, Capture, In, Out> {
         let closure = OneOf2::Variant2(self);
         ClosureOneOf2 { closure }
+    }
+}
+
+impl<C1, C2, In, Out> Fun<In, Out> for ClosureOneOf2<C1, C2, In, Out> {
+    fn call(&self, input: In) -> Out {
+        ClosureOneOf2::call(self, input)
     }
 }

--- a/src/one_of_variants/one_of3/closure_ref.rs
+++ b/src/one_of_variants/one_of3/closure_ref.rs
@@ -1,4 +1,4 @@
-use crate::{ClosureRef, OneOf3};
+use crate::{fun::FunRef, ClosureRef, OneOf3};
 
 type UnionClosures<C1, C2, C3, In, Out> =
     OneOf3<ClosureRef<C1, In, Out>, ClosureRef<C2, In, Out>, ClosureRef<C3, In, Out>>;
@@ -141,6 +141,15 @@ impl<C1, C2, C3, In, Out: ?Sized> ClosureRefOneOf3<C1, C2, C3, In, Out> {
             OneOf3::Variant1(fun) => fun.call(input),
             OneOf3::Variant2(fun) => fun.call(input),
             OneOf3::Variant3(fun) => fun.call(input),
+        }
+    }
+
+    /// Returns a reference to the captured data.
+    pub fn captured_data(&self) -> OneOf3<&C1, &C2, &C3> {
+        match &self.closure {
+            OneOf3::Variant1(x) => OneOf3::Variant1(x.captured_data()),
+            OneOf3::Variant2(x) => OneOf3::Variant2(x.captured_data()),
+            OneOf3::Variant3(x) => OneOf3::Variant3(x.captured_data()),
         }
     }
 
@@ -425,5 +434,11 @@ impl<Capture, In, Out: ?Sized> ClosureRef<Capture, In, Out> {
     pub fn into_oneof3_var3<Var1, Var2>(self) -> ClosureRefOneOf3<Var1, Var2, Capture, In, Out> {
         let closure = OneOf3::Variant3(self);
         ClosureRefOneOf3 { closure }
+    }
+}
+
+impl<C1, C2, C3, In, Out: ?Sized> FunRef<In, Out> for ClosureRefOneOf3<C1, C2, C3, In, Out> {
+    fn call(&self, input: In) -> &Out {
+        ClosureRefOneOf3::call(self, input)
     }
 }

--- a/src/one_of_variants/one_of3/closure_res_ref.rs
+++ b/src/one_of_variants/one_of3/closure_res_ref.rs
@@ -1,4 +1,4 @@
-use crate::{ClosureResRef, OneOf3};
+use crate::{fun::FunResRef, ClosureResRef, OneOf3};
 
 type UnionClosures<C1, C2, C3, In, Out, Error> = OneOf3<
     ClosureResRef<C1, In, Out, Error>,
@@ -158,6 +158,15 @@ impl<C1, C2, C3, In, Out: ?Sized, Error> ClosureResRefOneOf3<C1, C2, C3, In, Out
             OneOf3::Variant1(fun) => fun.call(input),
             OneOf3::Variant2(fun) => fun.call(input),
             OneOf3::Variant3(fun) => fun.call(input),
+        }
+    }
+
+    /// Returns a reference to the captured data.
+    pub fn captured_data(&self) -> OneOf3<&C1, &C2, &C3> {
+        match &self.closure {
+            OneOf3::Variant1(x) => OneOf3::Variant1(x.captured_data()),
+            OneOf3::Variant2(x) => OneOf3::Variant2(x.captured_data()),
+            OneOf3::Variant3(x) => OneOf3::Variant3(x.captured_data()),
         }
     }
 
@@ -468,5 +477,13 @@ impl<Capture, In, Out: ?Sized, Error> ClosureResRef<Capture, In, Out, Error> {
     ) -> ClosureResRefOneOf3<Var1, Var2, Capture, In, Out, Error> {
         let closure = OneOf3::Variant3(self);
         ClosureResRefOneOf3 { closure }
+    }
+}
+
+impl<C1, C2, C3, In, Out: ?Sized, Error> FunResRef<In, Out, Error>
+    for ClosureResRefOneOf3<C1, C2, C3, In, Out, Error>
+{
+    fn call(&self, input: In) -> Result<&Out, Error> {
+        ClosureResRefOneOf3::call(self, input)
     }
 }

--- a/src/one_of_variants/one_of3/closure_val.rs
+++ b/src/one_of_variants/one_of3/closure_val.rs
@@ -1,4 +1,4 @@
-use crate::{Closure, OneOf3};
+use crate::{fun::Fun, Closure, OneOf3};
 
 type UnionClosures<C1, C2, C3, In, Out> =
     OneOf3<Closure<C1, In, Out>, Closure<C2, In, Out>, Closure<C3, In, Out>>;
@@ -126,6 +126,15 @@ impl<C1, C2, C3, In, Out> ClosureOneOf3<C1, C2, C3, In, Out> {
             OneOf3::Variant1(fun) => fun.call(input),
             OneOf3::Variant2(fun) => fun.call(input),
             OneOf3::Variant3(fun) => fun.call(input),
+        }
+    }
+
+    /// Returns a reference to the captured data.
+    pub fn captured_data(&self) -> OneOf3<&C1, &C2, &C3> {
+        match &self.closure {
+            OneOf3::Variant1(x) => OneOf3::Variant1(x.captured_data()),
+            OneOf3::Variant2(x) => OneOf3::Variant2(x.captured_data()),
+            OneOf3::Variant3(x) => OneOf3::Variant3(x.captured_data()),
         }
     }
 
@@ -337,5 +346,11 @@ impl<Capture, In, Out> Closure<Capture, In, Out> {
     pub fn into_oneof3_var3<Var1, Var2>(self) -> ClosureOneOf3<Var1, Var2, Capture, In, Out> {
         let closure = OneOf3::Variant3(self);
         ClosureOneOf3 { closure }
+    }
+}
+
+impl<C1, C2, C3, In, Out> Fun<In, Out> for ClosureOneOf3<C1, C2, C3, In, Out> {
+    fn call(&self, input: In) -> Out {
+        ClosureOneOf3::call(self, input)
     }
 }

--- a/src/one_of_variants/one_of4/closure_val.rs
+++ b/src/one_of_variants/one_of4/closure_val.rs
@@ -1,4 +1,4 @@
-use crate::{Closure, OneOf4};
+use crate::{fun::Fun, Closure, OneOf2, OneOf4};
 
 type UnionClosures<C1, C2, C3, C4, In, Out> =
     OneOf4<Closure<C1, In, Out>, Closure<C2, In, Out>, Closure<C3, In, Out>, Closure<C4, In, Out>>;
@@ -128,6 +128,16 @@ impl<C1, C2, C3, C4, In, Out> ClosureOneOf4<C1, C2, C3, C4, In, Out> {
             OneOf4::Variant2(fun) => fun.call(input),
             OneOf4::Variant3(fun) => fun.call(input),
             OneOf4::Variant4(fun) => fun.call(input),
+        }
+    }
+
+    /// Returns a reference to the captured data.
+    pub fn captured_data(&self) -> OneOf4<&C1, &C2, &C3, &C4> {
+        match &self.closure {
+            OneOf4::Variant1(x) => OneOf4::Variant1(x.captured_data()),
+            OneOf4::Variant2(x) => OneOf4::Variant2(x.captured_data()),
+            OneOf4::Variant3(x) => OneOf4::Variant3(x.captured_data()),
+            OneOf4::Variant4(x) => OneOf4::Variant4(x.captured_data()),
         }
     }
 
@@ -379,5 +389,11 @@ impl<Capture, In, Out> Closure<Capture, In, Out> {
     ) -> ClosureOneOf4<Var1, Var2, Var3, Capture, In, Out> {
         let closure = OneOf4::Variant4(self);
         ClosureOneOf4 { closure }
+    }
+}
+
+impl<C1, C2, C3, C4, In, Out> Fun<In, Out> for ClosureOneOf4<C1, C2, C3, C4, In, Out> {
+    fn call(&self, input: In) -> Out {
+        ClosureOneOf4::call(self, input)
     }
 }

--- a/tests/fun_over_captures.rs
+++ b/tests/fun_over_captures.rs
@@ -1,0 +1,81 @@
+use orx_closure::*;
+use std::collections::{hash_map::RandomState, HashMap};
+
+#[test]
+fn test_fun() {
+    let fun = Capture(vec!["john".to_string(), "doe".to_string()]).fun(|x, i: usize| x[i].clone());
+    validate_fun(fun);
+
+    let fun = Capture(["john".to_string(), "doe".to_string()]).fun(|x, i: usize| x[i].clone());
+    validate_fun(fun);
+
+    let map: HashMap<usize, String, RandomState> =
+        HashMap::from_iter([(0usize, "john".to_string()), (1, "doe".to_string())].into_iter());
+    let fun = Capture(map).fun(|x, i: usize| x.get(&i).unwrap().clone());
+    validate_fun(fun);
+}
+fn validate_fun<F: Fun<usize, String>>(fun: F) {
+    assert_eq!(String::from("john"), fun.call(0));
+    assert_eq!(String::from("doe"), fun.call(1));
+}
+
+#[test]
+fn test_funref() {
+    let fun =
+        Capture(vec!["john".to_string(), "doe".to_string()]).fun_ref(|x, i: usize| x[i].as_str());
+    validate_fun_ref(fun);
+
+    let fun = Capture(["john".to_string(), "doe".to_string()]).fun_ref(|x, i: usize| x[i].as_str());
+    validate_fun_ref(fun);
+
+    let map: HashMap<usize, String, RandomState> =
+        HashMap::from_iter([(0usize, "john".to_string()), (1, "doe".to_string())].into_iter());
+    let fun = Capture(map).fun_ref(|x, i: usize| x.get(&i).unwrap().as_str());
+    validate_fun_ref(fun);
+}
+fn validate_fun_ref<F: FunRef<usize, str>>(fun: F) {
+    assert_eq!("john", fun.call(0));
+    assert_eq!("doe", fun.call(1));
+}
+
+#[test]
+fn test_funoptref() {
+    let fun = Capture(vec!["john".to_string(), "doe".to_string()])
+        .fun_option_ref(|x, i: usize| x.get(i).map(|x| x.as_str()));
+    validate_fun_opt_ref(fun);
+
+    let fun = Capture(["john".to_string(), "doe".to_string()])
+        .fun_option_ref(|x, i: usize| x.get(i).map(|x| x.as_str()));
+    validate_fun_opt_ref(fun);
+
+    let map: HashMap<usize, String, RandomState> =
+        HashMap::from_iter([(0usize, "john".to_string()), (1, "doe".to_string())].into_iter());
+    let fun = Capture(map).fun_option_ref(|x, i: usize| x.get(&i).map(|x| x.as_str()));
+    validate_fun_opt_ref(fun);
+}
+fn validate_fun_opt_ref<F: FunOptRef<usize, str>>(fun: F) {
+    assert_eq!(Some("john"), fun.call(0));
+    assert_eq!(Some("doe"), fun.call(1));
+    assert_eq!(None, fun.call(2));
+}
+
+#[test]
+fn test_funresref() {
+    let fun = Capture(vec!["john".to_string(), "doe".to_string()])
+        .fun_result_ref(|x, i: usize| x.get(i).map(|x| x.as_str()).ok_or(42));
+    validate_fun_res_ref(fun);
+
+    let fun = Capture(["john".to_string(), "doe".to_string()])
+        .fun_result_ref(|x, i: usize| x.get(i).map(|x| x.as_str()).ok_or(42));
+    validate_fun_res_ref(fun);
+
+    let map: HashMap<usize, String, RandomState> =
+        HashMap::from_iter([(0usize, "john".to_string()), (1, "doe".to_string())].into_iter());
+    let fun = Capture(map).fun_result_ref(|x, i: usize| x.get(&i).map(|x| x.as_str()).ok_or(42));
+    validate_fun_res_ref(fun);
+}
+fn validate_fun_res_ref<F: FunResRef<usize, str, usize>>(fun: F) {
+    assert_eq!(Ok("john"), fun.call(0));
+    assert_eq!(Ok("doe"), fun.call(1));
+    assert_eq!(Err(42), fun.call(2));
+}


### PR DESCRIPTION
`Fun` trait and its reference returning variants `FunRef`, `FunOptRef` and `FunResRef` are defined and implemented by the corresponding closure types.

Further, `Fun` is implemented by any `T` that implements `Fn` with the correct signature.

Additionally, `fn captured_data(&self) -> &Capture` method is implemented for all closures in order to provide a reference to the captured data. Since we do not forget the captured data just yet, no need to hide the data since it is immutable.